### PR TITLE
Update composer.json to use 6.* of guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     }
   },
   "require": {
-    "guzzlehttp/guzzle": "6.2.3",
+    "guzzlehttp/guzzle": "6.*",
     "symfony/serializer": "3.2.7",
     "symfony/property-access": "3.2.7",
     "doctrine/common": "2.7.2"


### PR DESCRIPTION
This was suggested by Plentymarkets to avoid compatibility issues with other modules. 